### PR TITLE
6.x 1.0

### DIFF
--- a/mediamosa_connector/changelog.md
+++ b/mediamosa_connector/changelog.md
@@ -1,4 +1,6 @@
-
+Changes 2.0.1
+-------------
+Fixed a bug in the debug display when more than 1 restcalls were executed per page.
 
 Changes 2.0.0
 -------------

--- a/mediamosa_connector/mediamosa_connector.class.inc
+++ b/mediamosa_connector/mediamosa_connector.class.inc
@@ -453,7 +453,7 @@ class mediamosa_connector {
     }
 
     if (variable_get('mediamosa_connector_debug', FALSE)) {
-      $_SESSION['mediamosa_connector_debug_info'] = $this->log;
+      $_SESSION['mediamosa_connector_debug_info'][] = $this->log;
     }
 
     // Must be HTTP 200 response.

--- a/mediamosa_connector/mediamosa_connector.module
+++ b/mediamosa_connector/mediamosa_connector.module
@@ -90,7 +90,7 @@ function mediamosa_connector_block($op = 'list', $delta = 0, $edit = array()) {
           foreach ($_SESSION['mediamosa_connector_debug_info'] as $log) {
 
             // Add row
-            $rows[] = theme('mediamosa_connector_call', $log);
+            $rows[] = theme('mediamosa_connector_call', reset($log));
           }
 
           $block['content'] = 'REST calls issued to build this page.';


### PR DESCRIPTION
Fixed a bug in the debug display when more than 1 restcalls were executed per page.
